### PR TITLE
Fix bug with average_spectra_cumul not using the right time array

### DIFF
--- a/hera_stats/average.py
+++ b/hera_stats/average.py
@@ -68,7 +68,7 @@ def average_spectra_cumul(uvp, blps, spw, polpair, mode='time', min_samples=1,
     
     if mode == 'time':
         # Get unique times from UVPSpec object
-        avail_times = np.unique(uvp.time_1_array)
+        avail_times = np.unique(uvp.time_avg_array)
         if avail_times.size <= min_samples:
             raise ValueError("min_samples is larger than or equal to the number "
                              "of available samples.")
@@ -92,9 +92,10 @@ def average_spectra_cumul(uvp, blps, spw, polpair, mode='time', min_samples=1,
             # Select subset of samples (good for performance)
             uvp_t.select(times=avail_times[:t], blpairs=blps)
 
-            # Average over blpair and time
+            # Average over blpair and time (use time_avg_array as the time key, 
+            # as this is what UVPSPec.select() uses)
             _avg = uvp_t.average_spectra([blps,], time_avg=True, inplace=False)
-            n_samples.append( np.unique(uvp_t.time_1_array).size )
+            n_samples.append( np.unique(uvp_t.time_avg_array).size )
             
             # Unpack data into array (spw=0 since we only selected one spw)
             ps = _avg.get_data((0, _avg.blpair_array[0], polpair)).flatten()

--- a/hera_stats/tests/test_average.py
+++ b/hera_stats/tests/test_average.py
@@ -2,20 +2,29 @@ import numpy as np
 import hera_pspec as hp
 import hera_stats as hs
 from hera_stats.data import DATA_PATH
+from pyuvdata import UVData
 import nose.tools as nt
-import os, sys
+import os, sys, copy
 import unittest
 
 class test_average():
 
     def setUp(self):
+        
         # Load pre-computed power spectra
         self.filepath = os.path.join(DATA_PATH, "uvp_data.h5")
         pc = hp.container.PSpecContainer(self.filepath, mode='r')
         self.uvp = pc.get_pspec("IDR2_1")[0]
+        
+        # Load example UVData
+        self.datafile = os.path.join(DATA_PATH, "zen.odd.xx.LST.1.28828.uvOCRSA")
+        self.uvd = UVData()
+        self.uvd.read_miriad(self.datafile)
     
     def tearDown(self):
-        pass
+        # Remove output data file
+        if os.path.exists("./out.h5"):
+            os.remove("./out.h5")
     
     def test_average_spectra_cumul(self):
         
@@ -90,6 +99,32 @@ class test_average():
                          self.uvp, blps, spw=0, polpair=('xx', 'xx'), 
                          mode='blpair', min_samples=1000000000, shuffle=False, 
                          time_avg=True, verbose=False)
+       
+        # Check that spectra with misaligned times can be averaged
+        uvd1 = self.uvd.select(times=np.unique(self.uvd.time_array)[::2], 
+                               inplace=False)
+        uvd2 = self.uvd.select(times=np.unique(self.uvd.time_array)[1::2], 
+                               inplace=False)
+        if os.path.exists("./out.h5"):
+            os.remove("./out.h5")
+        blps_toffset = [((38, 68), (37, 38)), ((38, 68), (52, 53))]
+        psc, ds = hp.pspecdata.pspec_run([uvd1, uvd2],
+                                         "./out.h5",
+                                         blpairs=blps_toffset,
+                                         verbose=False, overwrite=True, 
+                                         spw_ranges=[(50, 100)], 
+                                         rephase_to_dset=0,
+                                         broadcast_dset_flags=True, 
+                                         time_thresh=0.3)
+        uvp_toffset = psc.get_pspec(psc.groups()[0])[0]
+        
+        # Check basic operation of cumulative-in-time mode with offset times
+        ps, dly, nsamples = hs.average.average_spectra_cumul(
+                                uvp_toffset, blps_toffset, spw=0, 
+                                polpair=('xx', 'xx'), 
+                                mode='time', min_samples=1, shuffle=False, 
+                                time_avg=True, verbose=False)
+        
 if __name__ == "__main__":
     unittest.main()
 


### PR DESCRIPTION
`average_spectra_cumul` was getting time samples from the `time_1_array` in the input `UVPSpec` object, while a call to the `select()` method that it relies upon uses `time_avg_array` instead. If the time arrays of the two `UVData` objects used to create the `UVPSpec` object are not aligned, the two time arrays will be different. This would then lead to an error: `AssertionError: no selections provided matched any of the data`.

This PR fixes the issue by using `time_avg_array` as the correct reference array.