### PR TITLE
Calculate difference between per-bl data and mean over all bls within a redundant group

### DIFF
--- a/hera_stats/tests/test_average.py
+++ b/hera_stats/tests/test_average.py
@@ -108,7 +108,7 @@ class test_average():
         if os.path.exists("./out.h5"):
             os.remove("./out.h5")
         blps_toffset = [((38, 68), (37, 38)), ((38, 68), (52, 53))]
-        psc, ds = hp.pspecdata.pspec_run([uvd1, uvd2],
+        ds = hp.pspecdata.pspec_run([uvd1, uvd2],
                                          "./out.h5",
                                          blpairs=blps_toffset,
                                          verbose=False, overwrite=True, 
@@ -116,6 +116,7 @@ class test_average():
                                          rephase_to_dset=0,
                                          broadcast_dset_flags=True, 
                                          time_thresh=0.3)
+        psc = hp.PSpecContainer("./out.h5", mode='r')
         uvp_toffset = psc.get_pspec(psc.groups()[0])[0]
         
         # Check basic operation of cumulative-in-time mode with offset times
@@ -125,6 +126,22 @@ class test_average():
                                 mode='time', min_samples=1, shuffle=False, 
                                 time_avg=True, verbose=False)
         
+    def test_redundant_diff(self):
+        
+        # Get list of unique bls
+        bls = self.uvd.get_antpairs()
+        print("num bls:", len(bls))
+        pol = self.uvd.polarization_array[0]
+        
+        # Try to run function
+        _bls, diffs = hs.average.redundant_diff(self.uvd, bls, pol)
+        nt.assert_equal(len(_bls), len(diffs))
+        
+        # Re-run, no returning the mean
+        _bls, diffs, mean = hs.average.redundant_diff(self.uvd, bls, pol, 
+                                                      return_mean=True)
+        nt.assert_equal(mean.shape, diffs[0].shape)
+    
 if __name__ == "__main__":
     unittest.main()
 

--- a/hera_stats/utils.py
+++ b/hera_stats/utils.py
@@ -1,11 +1,13 @@
 # Extra utilities for hera_stats
-import os
-import copy
 import numpy as np
+import os, copy
 
 def plt_layout(req):
-    """Helper function for figuring out best layout of histogram table"""
-    # req is the requested number of plots. All numbers below it are potential divisors
+    """
+    Helper function for figuring out best layout of histogram table
+    """
+    # req is the requested number of plots. All numbers below it are 
+    # potential divisors
     divisors = np.arange(1,req)
 
     # How many empty plots would be left
@@ -60,6 +62,41 @@ def is_in_wrap(low, hi, angle):
         return True
 
     return False
+
+
+def trim_empty_bls(uvd, bl_grp):
+    """
+    Remove any baselines with zero data from a list of baseline groups.
+    
+    Parameters
+    ----------
+    uvd : UVData
+        Object containing data.
+    
+    bl_grp : list of list of baseline tuples or ints
+        List of groups of baselines.
+    
+    Returns
+    -------
+    bl_grp_trimmed : list of baseline tuples or ints
+        Copy of bl_grp with all zeroed bls removed.
+    """
+    # Try to convert to list of lists if it isn't already
+    if not isinstance(bl_grp[0], list):
+        bl_grp = [bl_grp,]
+    bl_grp_trimmed = []
+    
+    # Loop over groups
+    for grp in bl_grp:
+        
+        # Loop over bls in group
+        new_grp = []
+        for bl in grp:
+            flags = uvd.get_flags(bl)
+            if not np.all(flags == True):
+                new_grp.append(bl)
+        bl_grp_trimmed.append(new_grp)
+    return bl_grp_trimmed
 
 
 def trim_empty_blpairs(uvp, bl_grp, spw=0, pol='pI'):
@@ -130,4 +167,5 @@ def stacked_array(array_list):
             array_total = np.vstack((array_total, array_new))
         counter += 1
     return array_total
+
 


### PR DESCRIPTION
Add average.redundant_diff to calculate difference between data for each bl in a redundant group and the mean over the group.