### PR TITLE
Add new function and plotting function for antenna-antenna plots of red grp differences

### DIFF
--- a/hera_stats/plot.py
+++ b/hera_stats/plot.py
@@ -3,6 +3,7 @@ from . import stats, utils
 from pyuvdata import UVData
 import hera_pspec as hp
 import matplotlib.pyplot as plt
+import matplotlib.ticker as ticker
 from matplotlib import gridspec
 
 
@@ -347,3 +348,51 @@ def redgrp_corrmat(corr, red_grp, cmap='RdBu', figsize=(30.,20.),
     return fig
 
 
+def antenna_matrix(mat, ants, label=None, cmap='viridis'):
+    """
+    Plot 2D square array, intended to be a matrix of antenna vs antenna values 
+    of some quantity.
+    
+    Parameters
+    ----------
+    mat : array_like
+        2D square array containing matrix values to be plotted.
+    
+    ants : array_like
+        1D array of unique antennas represented in the matrix, in the same 
+        ordering as the input matrix.
+    
+    label : str, optional
+        Label for the plot (displayed as the colorbar label). Default: None.
+    
+    cmap : str, optional
+        Matplotlib colormap name. Default: 'viridis'.
+    
+    Returns
+    -------
+    fig : matplotlib.Figure
+        Matplotlib figure containing matshow.
+    """
+    # Plot matrix as matshow
+    fig = plt.figure()
+    ax = fig.add_subplot(111)
+    cax = ax.matshow(mat, cmap=cmap)
+    cbar = fig.colorbar(cax, fraction=0.045, pad=0.04) # reduce cbar height
+    cbar.set_label(label, fontsize=16)
+
+    # Add grid
+    for j in np.arange(0, ants.size, 10):
+        plt.axvline(j, color='k', alpha=0.2, ls='dashed')
+        plt.axhline(j, color='k', alpha=0.2, ls='dashed')
+
+    # Add tick labels for each antenna
+    ant_lbls = ["%d" % ant for ant in ants]
+    ax.set_xticklabels([''] + ant_lbls, rotation=90.)
+    ax.set_yticklabels([''] + ant_lbls)
+    ax.xaxis.set_major_locator(ticker.MultipleLocator(1))
+    ax.yaxis.set_major_locator(ticker.MultipleLocator(1))
+    
+    # Set sizes
+    plt.gcf().set_size_inches((12., 12.))
+    return fig
+    

--- a/hera_stats/tests/test_average.py
+++ b/hera_stats/tests/test_average.py
@@ -133,7 +133,6 @@ class test_average():
         
         # Get list of unique bls
         bls = self.uvd.get_antpairs()
-        print("num bls:", len(bls))
         pol = self.uvd.polarization_array[0]
         
         # Try to run function
@@ -145,6 +144,25 @@ class test_average():
                                                       return_mean=True)
         nt.assert_equal(mean.shape, diffs[0].shape)
     
+    def test_redundant_diff_summary(self):
+        
+        # Get redundant baselines contained in test UVData object
+        red_bls, lens, angs = hp.utils.get_reds(self.uvd, bl_error_tol=1.0, 
+                                                add_autos=False,
+                                                bl_len_range=(12., 100.), 
+                                                bl_deg_range=(0., 360.),
+                                                pick_data_ants=True)
+        # Get polarization
+        pol = self.uvd.polarization_array[0]
+        
+        # Try to run function
+        op = lambda d, m: np.max(d.real)
+        uniq_ants, mat = hs.average.redundant_diff_summary(
+                                          self.uvd, red_bls, pol, 
+                                          op_upper=op, op_lower=op, 
+                                          verbose=True)
+        nt.assert_equal(mat.shape[0], uniq_ants.size)
+        
 if __name__ == "__main__":
     unittest.main()
 

--- a/hera_stats/tests/test_plot.py
+++ b/hera_stats/tests/test_plot.py
@@ -166,7 +166,13 @@ class Test_Plot(unittest.TestCase):
         nt.assert_raises(TypeError, hs.plot.long_waterfall,
                                        self.uvh5_files, bl=123124, pol='xx', 
                                        title='x', mode='data', file_type='uvh5')
-                                       
+    
+    def test_antenna_matrix(self):
+        # Check to see if function runs
+        ants = np.arange(7)
+        mat = np.outer(ants, ants)
+        fig = hs.plot.antenna_matrix(mat, ants, label="test", cmap='viridis')
+                          
 if __name__ == "__main__":
     unittest.main()
 


### PR DESCRIPTION
Allows matrices of antenna vs. antenna summary statistics to be plotted. This is currently mostly focused on summary statistics of differences over redundant groups.