### PR TITLE
Change indent in docstring to stop sphinx complaining

### DIFF
--- a/hera_stats/plot.py
+++ b/hera_stats/plot.py
@@ -205,12 +205,14 @@ def scatter_bandpowers(uvp, x_dly, y_dly, keys, operator='abs', label=None,
     Example of `keys` argument:
     .. highlight:: python
     .. code-block:: python
-        red_grps, red_lens, red_angs = uvp.get_red_blpairs()
-        keys = {
-            'spws':     0,
-            'blpairs':  red_grps[0],
-            'polpairs': uvp.get_polpairs(),
-        }
+       
+       red_grps, red_lens, red_angs = uvp.get_red_blpairs()
+       keys = {
+       'spws': 0,
+       'blpairs':  red_grps[0],
+       'polpairs': uvp.get_polpairs(),
+       }
+    
     
     Parameters
     ----------

--- a/hera_stats/shuffle.py
+++ b/hera_stats/shuffle.py
@@ -18,15 +18,15 @@ def shuffle_data_redgrp(uvd, redgrps):
     Example:
       Original visibility (fixed time and pol, for freq. channels 1, 2, 3...):
       
-        bl_a = |a1|a2|a3|a4|...
-        bl_b = |b1|b2|b3|b4|...
-        bl_c = |c1|c2|c3|c4|...
+        bl_a = [a1, a2, a3, a4, ...]
+        bl_b = [b1, b2, b3, b4, ...]
+        bl_c = [c1, c2, c3, c4, ...]
     
-      Shuffled visibility:
+      Shuffled visibility (for example):
       
-        new_a = |b1|a2|c3|b4|...
-        new_b = |c1|c2|a3|a4|...
-        new_c = |a1|b2|b3|c4|...
+        new_a = [b1, a2, c3, b4, ...]
+        new_b = [c1, c2, a3, a4, ...]
+        new_c = [a1, b2, b3, c4, ...]
     
     Parameters
     ----------


### PR DESCRIPTION
Sphinx is throwing errors and warnings about indents and substitution character "|".